### PR TITLE
Prepare the sync ingest for a database rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,10 @@ deploy.firestore: setup
 	@gcloud firestore databases create --region=us-central
 
 deploy.firebase:
-	@firebase deploy
+	@firebase --project=${GOOGLE_CLOUD_PROJECT} deploy --only hosting
+
+deploy.firestore:
+	@firebase --project=${GOOGLE_CLOUD_PROJECT} deploy --only firestore
 
 deploy.lighthouse: setup
 	@gcloud run deploy lighthouse-server --no-allow-unauthenticated --image gcr.io/${GOOGLE_CLOUD_PROJECT}/lighthouse:${VERSION} --memory ${GOOGLE_CLOUD_RUN_LIGHTHOUSE_MEMORY} --concurrency 1
@@ -113,3 +116,6 @@ describe.phpcs: setup
 
 describe.sync: setup
 	@gcloud run services describe sync-server --format 'value(status.url)'
+
+delete.firestore:
+	@firebase --project=${GOOGLE_CLOUD_PROJECT} firestore:delete --all-collections

--- a/app/src/util/doSync.js
+++ b/app/src/util/doSync.js
@@ -23,7 +23,7 @@ const doSync = async () => {
     };
     const ingest = delta.ingest || false;
     const limitPageOne = (!ingest && !delta.theme && !delta.plugin);
-    const versions = limitPageOne ? 1 : ingest ? -1 : 0; /* eslint-disable-line no-nested-ternary */
+    const versions = limitPageOne || ingest ? 1 : 0;
 
     const getSyncListPage = async (page, type) => getSyncList({
         'request[browse]': 'updated',

--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,8 @@
     "source": "app"
   },
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "hosting": {
     "public": "web/.vuepress/dist",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,37 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "Status",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_datetime",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "Status",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_datetime",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/web/.vuepress/public/assets/app.js
+++ b/web/.vuepress/public/assets/app.js
@@ -36,4 +36,7 @@ const loadScript = async (url) => Promise.resolve(new Promise((resolve) => {
 
     // Initialize Firebase Analytics.
     firebase.analytics();
+
+    // Initialize Firebase Performance Monitoring.
+    firebase.performance();
 })();


### PR DESCRIPTION
## Summary

- Limits the ingest to only one previous version
- Initializes performance monitoring
- Adds Firestore indexes file

## Checklist

- [x] My code is tested and passes existing [tests](https://github.com/wptide/wptide.org/tree/develop/web/docs/contributing#tests).
- [x] My code follows the [Tide Contributing Guide](https://github.com/wptide/wptide.org/tree/develop/web/docs/contributing) (updates are often made to the guidelines, check it out periodically).
